### PR TITLE
Scale dry air mass on initalization for non-analytic, non-restart simulations

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3697,6 +3697,7 @@ if ($dyn =~ /mpas/) {
     add_default($nl, 'mpas_smdiv');
     add_default($nl, 'mpas_apvm_upwinding');
     add_default($nl, 'mpas_h_ScaleWithMesh');
+    add_default($nl, 'mpas_scale_dry_air_mass');
     add_default($nl, 'mpas_zd');
     add_default($nl, 'mpas_xnutr');
     add_default($nl, 'mpas_cam_coef');

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2721,6 +2721,7 @@
 <mpas_smdiv                   > 0.1D0 </mpas_smdiv>
 <mpas_apvm_upwinding          > 0.5D0 </mpas_apvm_upwinding>
 <mpas_h_ScaleWithMesh         > .true. </mpas_h_ScaleWithMesh>
+<mpas_scale_dry_air_mass      > .false. </mpas_scale_dry_air_mass>
 <mpas_zd                      > 22000.0D0 </mpas_zd>
 <mpas_xnutr                   > 0.2D0 </mpas_xnutr>
 <mpas_cam_coef                > 0.0D0 </mpas_cam_coef>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -7594,6 +7594,12 @@ in MPAS dycore.
 Default: TRUE
 </entry>
 
+<entry id="mpas_scale_dry_air_mass" type="logical" category="mpas"
+       group="nhyd_model" valid_values="">
+Scale dry-air mass at initaliation for the MPAS dycore.
+Default: FALSE
+</entry>
+
 <entry id="mpas_zd" type="real" category="mpas"
        group="damping" valid_values="">
 Height in meters above MSL to begin w-damping profile in MPAS dycore.

--- a/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
@@ -2571,7 +2571,7 @@ contains
     !>
     !
     !-----------------------------------------------------------------------
-    subroutine cam_mpas_global_sum_real(dminfo, rarray, global_sum)
+    function cam_mpas_global_sum_real(rarray) result(global_sum)
 
        use mpas_kind_types, only : RKIND
        use mpas_dmpar, only : mpas_dmpar_sum_real, mpas_dmpar_bcast_real
@@ -2579,16 +2579,15 @@ contains
        implicit none
 
        ! Input variables
-       type (dm_info), intent(in) :: dminfo
        real (RKIND), dimension(:), intent(in) :: rarray
-       real (RKIND), intent(out) :: global_sum
+       real (RKIND) :: global_sum
 
        real (RKIND) :: local_sum
 
        local_sum = sum(rarray)
-       call mpas_dmpar_sum_real(dminfo, local_sum, global_sum)
+       call mpas_dmpar_sum_real(domain_ptr % dminfo, local_sum, global_sum)
 
-    end subroutine cam_mpas_global_sum_real
+    end function cam_mpas_global_sum_real
 
 
 end module cam_mpas_subdriver

--- a/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/cam_mpas_subdriver.F90
@@ -32,7 +32,9 @@ module cam_mpas_subdriver
               cam_mpas_cell_to_edge_winds, &
               cam_mpas_run, &
               cam_mpas_finalize, &
-              cam_mpas_debug_stream
+              cam_mpas_debug_stream, &
+              cam_mpas_global_sum_real
+
     public :: corelist, domain_ptr
 
     private
@@ -2555,6 +2557,38 @@ contains
        end if
 
     end subroutine cam_mpas_debug_stream
+
+
+    !-----------------------------------------------------------------------
+    !  routine cam_mpas_global_sum_real
+    !
+    !> \brief  Compute the global sum of real array
+    !> \author Miles Curry
+    !> \date   25 February 2021
+    !> \details
+    !>  This routine computes a global sum of a real array across all tasks
+    !> in a communicator and returns that sum to all tasks.
+    !>
+    !
+    !-----------------------------------------------------------------------
+    subroutine cam_mpas_global_sum_real(dminfo, rarray, global_sum)
+
+       use mpas_kind_types, only : RKIND
+       use mpas_dmpar, only : mpas_dmpar_sum_real, mpas_dmpar_bcast_real
+
+       implicit none
+
+       ! Input variables
+       type (dm_info), intent(in) :: dminfo
+       real (RKIND), dimension(:), intent(in) :: rarray
+       real (RKIND), intent(out) :: global_sum
+
+       real (RKIND) :: local_sum
+
+       local_sum = sum(rarray)
+       call mpas_dmpar_sum_real(dminfo, local_sum, global_sum)
+
+    end subroutine cam_mpas_global_sum_real
 
 
 end module cam_mpas_subdriver

--- a/src/dynamics/mpas/dyn_comp.F90
+++ b/src/dynamics/mpas/dyn_comp.F90
@@ -1046,7 +1046,7 @@ subroutine read_inidat(dyn_in)
    theta_m(:,1:nCellsSolve) = theta(:,1:nCellsSolve) * (1.0_r8 + Rv_over_Rd * tracers(ixqv,:,1:nCellsSolve))
 
    ! if (.not. analytic_ic_active()) then  ! scale dry-air mass
-   !   call cam_mpas_global_sum_real( domain_ptr % dminfo, areaCell(1:nCellsSolve), surface_integral )
+   !   surface_integral = cam_mpas_global_sum_real(areaCell(1:nCellsSolve))
    !   write(iulog,*) subname//': Cell area test value = ', surface_integral
    !   test_value = sqrt(surface_integral/(4.0_r8*pi))
    !   write(iulog,*) subname//': earth radius from area = ', test_value
@@ -1073,9 +1073,9 @@ subroutine read_inidat(dyn_in)
 
       ! (3) compute average global dry surface pressure                                                                                           
       preliminary_dry_surface_pressure(1:nCellsSolve) =  preliminary_dry_surface_pressure(1:nCellsSolve)*areaCell(1:nCellsSolve)
-      call cam_mpas_global_sum_real( domain_ptr % dminfo, areaCell(1:nCellsSolve), sphere_surface_area )
-      call cam_mpas_global_sum_real( domain_ptr % dminfo, preliminary_dry_surface_pressure(1:nCellsSolve), preliminary_avg_dry_surface_pressure )
-      preliminary_avg_dry_surface_pressure = preliminary_avg_dry_surface_pressure/sphere_surface_area
+      sphere_surface_area = cam_mpas_global_sum_real(areaCell(1:nCellsSolve))
+      preliminary_avg_dry_surface_pressure = cam_mpas_global_sum_real(preliminary_dry_surface_pressure(1:nCellsSolve)) &
+                                                                      /sphere_surface_area
       write(iulog,*) subname//': initial dry globally avg surface pressure (hPa) = ', preliminary_avg_dry_surface_pressure/100.
 
       ! (4) scale dry air density                                                                                                                 

--- a/src/utils/physconst.F90
+++ b/src/utils/physconst.F90
@@ -94,6 +94,10 @@ real(r8), public, parameter :: mwh2o2      =  34._r8
 real(r8), public, parameter :: mwdms       =  62._r8
 real(r8), public, parameter :: mwnh4       =  18._r8
 
+! CESM reference dry mass pressure with/without topo
+real(r8), public, parameter :: ps_dry_topo   = 98288.0_r8
+real(r8), public, parameter :: ps_dry_notopo = 101325._r8 - 245._r8
+
 
 ! modifiable physical constants for aquaplanet
 


### PR DESCRIPTION
This merge adds code to the MPAS dycore which allows the ability to scale the dry air mass for non-analytic and non-restart simulations. To enable dry air mass scaling, the namelist option, mpas_scale_dry_air_mass, which this merge also introduces, must be set to .true. in user_nl_cam.

This merge also adds a routine that can compute the global sum of a one dimensional real array across all tasks. For now, this single real routine is needed, but a future commit can add an additional routine to compute the global sum of a integer array and could add an abstract interface for both functions.